### PR TITLE
🧹 Refactor error handling in debug route

### DIFF
--- a/server/internal/routes/debug.go
+++ b/server/internal/routes/debug.go
@@ -43,24 +43,22 @@ func RegisterDebugEndpoints(humaAPI huma.API, prefix string, sessionService sess
 		func(ctx context.Context, input *struct {
 			UserId string `path:"user_id" example:"user_12345" doc:"User ID to list sessions for"`
 		}) (response *debugListSessionsResponse, err error) {
-			resp := &debugListSessionsResponse{}
 			database, err := GetDB(provider)
 			if err != nil {
-				resp.Body.SessionIds = []string{fmt.Sprintf("Database unavailable: %v", err)}
-				return resp, nil
+				return nil, huma.Error500InternalServerError(fmt.Sprintf("Database unavailable: %v", err))
 			}
 
 			userUUID, err := pgutil.ParseUUID(input.UserId)
 			if err != nil {
-				resp.Body.SessionIds = []string{fmt.Sprintf("Invalid user ID: %v", err)}
-				return resp, nil
+				return nil, huma.Error400BadRequest(fmt.Sprintf("Invalid user ID: %v", err))
 			}
 
 			conversations, err := database.Conversations().ListByUser(ctx, userUUID)
 			if err != nil {
-				resp.Body.SessionIds = []string{fmt.Sprintf("Could not retrieve sessions for user: %s", input.UserId)}
-				return resp, nil
+				return nil, huma.Error500InternalServerError(fmt.Sprintf("Could not retrieve sessions for user: %s", input.UserId))
 			}
+
+			resp := &debugListSessionsResponse{}
 			for _, c := range conversations {
 				resp.Body.SessionIds = append(resp.Body.SessionIds, c.SessionID)
 			}


### PR DESCRIPTION
🎯 **What:** Improved error handling in the `debug_list_sessions` endpoint in `server/internal/routes/debug.go`. Errors such as database unavailability, invalid UUID format, or failed conversation queries now correctly return 500 or 400 HTTP errors instead of returning a 200 OK response with the error embedded in the response body.
💡 **Why:** This makes the error handling consistent with standard REST practices and the rest of the application (which already utilizes `huma.Error...` methods). Returning specific HTTP status codes simplifies client-side error handling and debugging.
✅ **Verification:** I verified the changes by formatting the file with `gofmt` and ensuring the entire server package builds correctly. The `huma` error usage matches the surrounding pattern in the debug file. I have also passed the code review tool.
✨ **Result:** Better maintainability, readability, and correct HTTP response codes for API failure scenarios.

---
*PR created automatically by Jules for task [1758052971060742413](https://jules.google.com/task/1758052971060742413) started by @SimHoZebs*