### PR TITLE
🧹 Refactor: Centralize GOOGLE_API_KEY environment resolution in config package

### DIFF
--- a/server/internal/agents/model.go
+++ b/server/internal/agents/model.go
@@ -2,7 +2,6 @@ package agents
 
 import (
 	"context"
-	"os"
 
 	"github.com/simhozebs/mugo/internal/config"
 	"google.golang.org/adk/model"
@@ -14,6 +13,6 @@ func NewGeminiModel() (model.LLM, error) {
 	return gemini.NewModel(
 		context.Background(),
 		config.ModelName,
-		&genai.ClientConfig{APIKey: os.Getenv("GOOGLE_API_KEY")},
+		&genai.ClientConfig{APIKey: config.GetGoogleAPIKey()},
 	)
 }

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -31,6 +31,11 @@ func GetTranscriptionServerURL() string {
 	return url
 }
 
+// GetGoogleAPIKey returns the Google API key from environment variable.
+func GetGoogleAPIKey() string {
+	return os.Getenv("GOOGLE_API_KEY")
+}
+
 // GetDatabaseURL returns the database URL from environment variable.
 func GetDatabaseURL() string {
 	return os.Getenv("DATABASE_URL")


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Direct access of `os.Getenv("GOOGLE_API_KEY")` in `server/internal/agents/model.go` bypassing the `config` package which handles environment variables throughout the repository.

💡 **Why:** How this improves maintainability
Moving environment variables access to the centralized `config` package improves testability and environment management, keeping access logic uniform and preventing loose scattered `os.Getenv` calls.

✅ **Verification:** How you confirmed the change is safe
Ran `make verify` successfully, which covered linting, building, and executing all existing tests on mobile and backend.
Code builds and tests pass, functionality is unchanged.

✨ **Result:** The improvement achieved
Reduced duplication and hardcoded assumptions about where the google api key comes from. Consistent configuration management by reading properties only via `server/internal/config`.

---
*PR created automatically by Jules for task [9715533736689789561](https://jules.google.com/task/9715533736689789561) started by @SimHoZebs*